### PR TITLE
Fix for quiet mode to stop issues with firebase table of contents

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ import readline from "readline";
 import TailFile from "@logdna/tail-file";
 import colorizer from "json-colorizer";
 
-const QUIET_STRING = ["functions", "hosting", "storage", "pubsub"];
+const QUIET_STRING = ["functions:", " hosting:", "storage:", "pubsub:"];
 
 const quiet = process.argv.indexOf("--quiet");
 const prettyOff = process.argv.indexOf("--pretty-off");


### PR DESCRIPTION
When quiet mode is enabled there is an error with the table of contents printed to the console, this little patch fixes that.